### PR TITLE
Aligned to Grails 7.0.0 minimum Java version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(17)
     }
     withJavadocJar()
     withSourcesJar()


### PR DESCRIPTION
Grails 7 will have Java 17 as minimum JVM requirement